### PR TITLE
Fix test flakiness

### DIFF
--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/TeeCommandTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/TeeCommandTest.scala
@@ -77,7 +77,7 @@ class TeeCommandTest extends CommonWordSpec {
   }
 
   private def getTempFilePath(): Path = {
-    Files.createTempFile("teecommand", Random.nextString(5))
+    Files.createTempFile("teecommand", ".tmp")
   }
 
   private def readTempFile(path: Path): List[String] = {


### PR DESCRIPTION
Why:
-`Files.createTempFile("teecommand", Random.nextString(5))` is flaky on machine
  - Random.nextString(5) generates characters that my filesystem doesn't like:
```
  java.nio.file.InvalidPathException: Malformed input or input contains unmappable chacraters: teecommand4544018799957168051?????
  at sun.nio.fs.UnixPath.encode(UnixPath.java:147)
  at sun.nio.fs.UnixPath.<init>(UnixPath.java:71)
  at sun.nio.fs.UnixFileSystem.getPath(UnixFileSystem.java:281)
  at java.nio.file.TempFileHelper.generatePath(TempFileHelper.java:60)
  at java.nio.file.TempFileHelper.create(TempFileHelper.java:127)
  at java.nio.file.TempFileHelper.createTempFile(TempFileHelper.java:161)
  at java.nio.file.Files.createTempFile(Files.java:848)
  at com.sumologic.shellbase.commands.TeeCommandTest.com$sumologic$shellbase$commands$TeeCommandTest$$getTempFilePath(TeeCommandTest.scala:80)
  at com.sumologic.shellbase.commands.TeeCommandTest$$anonfun$1$$anonfun$apply$mcV$sp$3.apply$mcV$sp(TeeCommandTest.scala:60)
  at com.sumologic.shellbase.commands.TeeCommandTest$$anonfun$1$$anonfun$apply$mcV$sp$3.apply(TeeCommandTest.scala:54)
  ...
```
- File.createTempFile already got random middle:
https://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html#createTempFile(java.nio.file.Path,%20java.lang.String,%20java.lang.String,%20java.nio.file.attribute.FileAttribute...)

Tests:
- cd shellbase-core; mvn test