### PR TITLE
Jacek better help

### DIFF
--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommand.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommand.scala
@@ -154,7 +154,12 @@ abstract class ShellCommand(val name: String,
 
     val txt = s"$name ${arguments.mkString(" ")}"
 
-    new HelpFormatter().printHelp(txt, options)
+    new HelpFormatter().printHelp(HelpFormatter.DEFAULT_WIDTH, txt, helpText, options,
+      null, // footer
+      true) // print an automatically generated usage statement, instead of:
+      //  usage: sleep period
+      // It prints:
+      //  usage: sleep period [-v]
   }
 
   final def completer = {

--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommandSet.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommandSet.scala
@@ -146,16 +146,13 @@ class ShellCommandSet(name: String, helpText: String, aliases: List[String] = Li
         true
       case command :: rest =>
         findCommand(command) match {
-          case Some(shellCommand) if rest.isEmpty =>
+          case Some(shellCommandSet: ShellCommandSet) => shellCommandSet.printHelp(rest)
+          case Some(shellCommand) if rest.nonEmpty =>
+            printf("Command '%s' doesn't have subcommands", command)
+            false
+          case Some(shellCommand) =>
             shellCommand.help
             true
-          case Some(shellCommand) =>
-            shellCommand match {
-              case shellCommandSet: ShellCommandSet => shellCommandSet.printHelp(rest)
-              case _  =>
-                printf("Command '%s' doesn't have subcommands", command)
-                false
-            }
           case None =>
             printf("Command '%s' unknown.", command)
             false

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellCommandSetTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellCommandSetTest.scala
@@ -36,6 +36,16 @@ class ShellCommandSetTest extends CommonWordSpec {
       run(sut, "test") should be(true)
     }
 
+    "support multi level help" in {
+      val sut = new ShellCommandSet("test", "set help text")
+      val nested = new ShellCommandSet("nested", "some help")
+      sut.commands += new TestCommand("one")
+      sut.commands += nested
+      nested.commands += new TestCommand("two")
+      run(sut, "help test one") should be(true)
+      run(sut, "help test nested two") should be(true)
+    }
+
     "execute commands in the set" in {
       val sut = new ShellCommandSet("test", "set help text")
       val one = new TestCommand("one")

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/TeeCommandTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/TeeCommandTest.scala
@@ -77,7 +77,7 @@ class TeeCommandTest extends CommonWordSpec {
   }
 
   private def getTempFilePath(): Path = {
-    Files.createTempFile("teecommand", Random.nextString(5))
+    Files.createTempFile("teecommand", ".tmp")
   }
 
   private def readTempFile(path: Path): List[String] = {


### PR DESCRIPTION
Read after: https://github.com/SumoLogic/shellbase/pull/14

Why:
- improve help system
- print helpText. Instead of:
```
usage: sleep period
 -v,--verbose   whether to print . every second while sleeping
```
print:
```
usage: sleep period [-v]
Sleeps the specified time period.
 -v,--verbose   whether to print . every second while sleeping
```
- display subcommands, instead of:
```
usage: rng
```
print:
```
Available commands: 
  boolean         Generates a random boolean
  double          Generates a random double
  float           Generates a random float
  gaussian        Generates a random gaussian
  help            Print online help.
  int             Generates a random int
  long            Generates a random long
```
- support multi level help, `? rng int` should work instead of displaying an error

Tests:
- added unit test
- tested manually
