### PR TITLE
Add argument to hide some commands from help.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.sumologic.shellbase</groupId>
   <artifactId>all</artifactId>
   <name>all</name>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <licenses>
     <license>

--- a/shellbase-core/pom.xml
+++ b/shellbase-core/pom.xml
@@ -3,12 +3,12 @@
   <artifactId>shellbase-core</artifactId>
   <name>shellbase-core</name>
   <packaging>jar</packaging>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
 
   <parent>
     <artifactId>all</artifactId>
     <groupId>com.sumologic.shellbase</groupId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellBase.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellBase.scala
@@ -91,7 +91,7 @@ abstract class ShellBase(val name: String) {
   /**
     * Hide in help built-in commands.
     */
-  def hideInHelpBuiltInCommands(name: String): Boolean = false
+  def hideBuiltInCommandsFromHelp(commandName: String): Boolean = false
 
   /**
     * Manages notifications
@@ -324,36 +324,36 @@ abstract class ShellBase(val name: String) {
   val subCommandExtractor = ShellBase.SubCommandExtractor
 
   rootSet.commands += new ClearCommand {
-    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+    override val hiddenInHelp = hideBuiltInCommandsFromHelp(name)
   }
 
   rootSet.commands += new ExitCommand(exitShell)  {
-    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+    override val hiddenInHelp = hideBuiltInCommandsFromHelp(name)
   }
 
   rootSet.commands += new SleepCommand  {
-    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+    override val hiddenInHelp = hideBuiltInCommandsFromHelp(name)
   }
 
   rootSet.commands += new EchoCommand  {
-    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+    override val hiddenInHelp = hideBuiltInCommandsFromHelp(name)
   }
 
   rootSet.commands += new TeeCommand(runCommand)  {
-    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+    override val hiddenInHelp = hideBuiltInCommandsFromHelp(name)
   }
 
   rootSet.commands += new TimeCommand(runCommand)  {
-    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+    override val hiddenInHelp = hideBuiltInCommandsFromHelp(name)
   }
 
   rootSet.commands += new RunScriptCommand(scriptDir, scriptExtension, runCommand, parseLine)  {
-    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+    override val hiddenInHelp = hideBuiltInCommandsFromHelp(name)
   }
 
   rootSet.commands += new NotificationCommandSet(notificationManager)  {
     // NOTE(chris, 2014-02-05): This has to be near the end for overrides to work
-    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+    override val hiddenInHelp = hideBuiltInCommandsFromHelp(name)
   }
 }
 

--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellBase.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellBase.scala
@@ -89,6 +89,11 @@ abstract class ShellBase(val name: String) {
   def historyPath: File = new File("%s/.%s_history".format(System.getProperty("user.home"), name))
 
   /**
+    * Hide in help built-in commands.
+    */
+  def hideInHelpBuiltInCommands(name: String): Boolean = false
+
+  /**
     * Manages notifications
     */
   lazy val notificationManager: ShellNotificationManager = new InMemoryShellNotificationManager(Seq(new RingingNotification))
@@ -318,21 +323,38 @@ abstract class ShellBase(val name: String) {
 
   val subCommandExtractor = ShellBase.SubCommandExtractor
 
-  rootSet.commands += new ClearCommand
+  rootSet.commands += new ClearCommand {
+    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+  }
 
-  rootSet.commands += new ExitCommand(exitShell)
+  rootSet.commands += new ExitCommand(exitShell)  {
+    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+  }
 
-  rootSet.commands += new SleepCommand
+  rootSet.commands += new SleepCommand  {
+    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+  }
 
-  rootSet.commands += new EchoCommand
+  rootSet.commands += new EchoCommand  {
+    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+  }
 
-  rootSet.commands += new TeeCommand(runCommand)
+  rootSet.commands += new TeeCommand(runCommand)  {
+    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+  }
 
-  rootSet.commands += new TimeCommand(runCommand)
+  rootSet.commands += new TimeCommand(runCommand)  {
+    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+  }
 
-  rootSet.commands += new RunScriptCommand(scriptDir, scriptExtension, runCommand, parseLine)
+  rootSet.commands += new RunScriptCommand(scriptDir, scriptExtension, runCommand, parseLine)  {
+    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+  }
 
-  rootSet.commands += new NotificationCommandSet(notificationManager) // NOTE(chris, 2014-02-05): This has to be near the end for overrides to work
+  rootSet.commands += new NotificationCommandSet(notificationManager)  {
+    // NOTE(chris, 2014-02-05): This has to be near the end for overrides to work
+    override val hiddenInHelp = hideInHelpBuiltInCommands(name)
+  }
 }
 
 object ShellBase {

--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommand.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommand.scala
@@ -32,7 +32,8 @@ import scala.concurrent.Future
 abstract class ShellCommand(val name: String,
                             val helpText: String,
                             val aliases: List[String] = List[String](),
-                            val deprecated: Boolean = false) {
+                            val deprecated: Boolean = false,
+                            val hiddenInHelp: Boolean = false) {
 
   protected val _logger = LoggerFactory.getLogger(getClass)
   protected lazy val prompter = new ShellPrompter()

--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommandSet.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommandSet.scala
@@ -152,7 +152,7 @@ class ShellCommandSet(name: String, helpText: String, aliases: List[String] = Li
           printf("  %-15s %s%n", cmd.name, cmd.helpText)
         })
         if (somethingWasHidden) {
-          printf("Some commands was hidden. Use [-%s] flag to show all.%n", ShowAllCommands.shortName)
+          println(s"Some commands was hidden. Use [-${ShowAllCommands.shortName}] flag to show all.")
         }
         true
       case command :: rest =>

--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommandSet.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommandSet.scala
@@ -18,8 +18,10 @@
  */
 package com.sumologic.shellbase
 
+import com.sumologic.shellbase.cmdline.CommandLineFlag
 import jline.console.completer.AggregateCompleter
-import org.apache.commons.cli.CommandLine
+import org.apache.commons.cli.{CommandLine, Options}
+import com.sumologic.shellbase.cmdline.RichCommandLine._
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ListBuffer
@@ -136,17 +138,26 @@ class ShellCommandSet(name: String, helpText: String, aliases: List[String] = Li
     })
   }
 
-  protected def printHelp(args: List[String]): Boolean = {
+  protected def printHelp(args: List[String], showAllCommands: Boolean): Boolean = {
     args match {
       case Nil =>
         printf("Available commands: %n")
-        for (cmd <- commands.filterNot(_.deprecated).sortBy(_.name)) {
+        var filteredCommands = commands.filterNot(_.deprecated)
+        var somethingWasHidden = false
+        if (!showAllCommands) {
+          somethingWasHidden = filteredCommands.exists(_.hiddenInHelp)
+          filteredCommands = filteredCommands.filterNot(_.hiddenInHelp)
+        }
+        filteredCommands.sortBy(_.name).foreach(cmd => {
           printf("  %-15s %s%n", cmd.name, cmd.helpText)
+        })
+        if (somethingWasHidden) {
+          printf("Some commands was hidden. Use [-%s] flag to show all.%n", ShowAllCommands.shortName)
         }
         true
       case command :: rest =>
         findCommand(command) match {
-          case Some(shellCommandSet: ShellCommandSet) => shellCommandSet.printHelp(rest)
+          case Some(shellCommandSet: ShellCommandSet) => shellCommandSet.printHelp(rest, showAllCommands)
           case Some(shellCommand) if rest.nonEmpty =>
             printf("Command '%s' doesn't have subcommands", command)
             false
@@ -164,12 +175,20 @@ class ShellCommandSet(name: String, helpText: String, aliases: List[String] = Li
   // Commands available with all command sets.
   // -----------------------------------------------------------------------------------------------
 
+  private val ShowAllCommands = new CommandLineFlag("a", "all", "Show all commands, including hidden")
+
   commands += new ShellCommand("help", "Print online help.", List("?")) {
 
     override def maxNumberOfArguments = Int.MaxValue
 
     def execute(cmdLine: CommandLine) = {
-      printHelp(cmdLine.getArgs.toList.map(_.trim).filter(_.nonEmpty))
+      val showAllCommands = cmdLine.checkFlag(ShowAllCommands)
+      printHelp(cmdLine.getArgs.toList.map(_.trim).filter(_.nonEmpty), showAllCommands)
+    }
+
+    override def addOptions(opts: Options): Unit = {
+      super.addOptions(opts)
+      opts += ShowAllCommands
     }
   }
 }

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellCommandSetTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellCommandSetTest.scala
@@ -44,6 +44,8 @@ class ShellCommandSetTest extends CommonWordSpec {
       nested.commands += new TestCommand("two")
       run(sut, "help test one") should be(true)
       run(sut, "help test nested two") should be(true)
+      run(sut, "help -a test nested two") should be(true)
+      run(sut, "help --all test") should be(true)
     }
 
     "execute commands in the set" in {

--- a/shellbase-example/pom.xml
+++ b/shellbase-example/pom.xml
@@ -3,12 +3,12 @@
   <artifactId>shellbase-example</artifactId>
   <name>shellbase-example</name>
   <packaging>jar</packaging>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
 
   <parent>
     <artifactId>all</artifactId>
     <groupId>com.sumologic.shellbase</groupId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.sumologic.shellbase</groupId>
       <artifactId>shellbase-core</artifactId>
-      <version>1.0.2-SNAPSHOT</version>
+      <version>1.1.0-SNAPSHOT</version>
     </dependency>
 
   </dependencies>

--- a/shellbase-slack/pom.xml
+++ b/shellbase-slack/pom.xml
@@ -4,12 +4,12 @@
   <artifactId>shellbase-slack</artifactId>
   <name>shellbase-slack</name>
   <packaging>jar</packaging>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
 
   <parent>
     <artifactId>all</artifactId>
     <groupId>com.sumologic.shellbase</groupId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.sumologic.shellbase</groupId>
       <artifactId>shellbase-core</artifactId>
-      <version>1.0.2-SNAPSHOT</version>
+      <version>1.1.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Why:
- listing of commands is getting cluttered, too many of them
- be able to hide commands from help, especially those which are mostly useful in scripts (e.g. `sleep`, `tee`) or helpers (`clear`)

Tests:
- Run all tests, added some case.
- Manually played with ExampleShell to confirm it looks nice.

Who should merge this: reviewer