### PR TITLE
suppressed notifications from the `notifications` command set itself

### DIFF
--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommand.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommand.scala
@@ -135,6 +135,11 @@ abstract class ShellCommand(val name: String,
     */
   def argCompleter: Completer = new NullCompleter
 
+  /**
+    * Returns `true` iff notifications should be run for this command
+    */
+  def shouldRunNotifications(arguments: List[String], commandPath: List[String] = List()): Boolean = true
+
   // -----------------------------------------------------------------------------------------------
   // Internals.
   // -----------------------------------------------------------------------------------------------

--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommandSet.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommandSet.scala
@@ -96,6 +96,13 @@ class ShellCommandSet(name: String, helpText: String, aliases: List[String] = Li
     }
   }
 
+  override def shouldRunNotifications(args: List[String], commandPath: List[String]): Boolean =
+    args match {
+      case command :: arguments =>
+        findCommand(command).exists(_.shouldRunNotifications(arguments, commandPath ++ List(command.trim)))
+      case _ => false
+    }
+
   // NOTE(stefan, 2013-12-31): Disable the validation done in ShellCommand, executeLine does
   // something comparable that makes more sense for this use case.
   override def validate(cmdLine: CommandLine): Option[String] = None

--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/notifications/NotificationCommandSet.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/notifications/NotificationCommandSet.scala
@@ -27,6 +27,8 @@ import org.apache.commons.cli.{CommandLine, Options}
 class NotificationCommandSet(manager: ShellNotificationManager)
   extends ShellCommandSet("notifications", "Helps manage notifications for the shell") {
 
+  override def shouldRunNotifications(arguments: List[String], commandPath: List[String] = List()) = false
+
   commands += new ShellCommand("list", "List available notification types and their status") {
     override def execute(cmdLine: CommandLine): Boolean = {
       val table = new ASCIITable[String]

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBaseTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBaseTest.scala
@@ -153,7 +153,7 @@ class ShellBaseTest extends CommonWordSpec {
       assert(notifications.toList == List(("tsh", "Command finished successfully: 'echo hello world'")))
     }
 
-    "don't run notifications for the 'notifications' command set" in {
+    "not run notifications for the 'notifications' command set" in {
       import scala.collection.mutable
       val notifications = new mutable.MutableList[(String, String)]
       val notification = new ShellNotification {


### PR DESCRIPTION
also changed notification messages format:
- `$name` is now part of the title so isn't needed in the message
- command text is included in the message