### PR TITLE
Changing RichCommandLine to not System.exit()

### DIFF
--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommand.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommand.scala
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory
 import scala.collection.JavaConversions._
 import scala.concurrent.Future
 
+class ExitShellCommandException(message: String) extends RuntimeException(message)
+
 /**
   * Definition of a shell command.
   */
@@ -72,6 +74,11 @@ abstract class ShellCommand(val name: String,
       }
     } catch {
       case e: IllegalArgumentException => {
+        println(ShellColors.red(e.getMessage))
+        _logger.debug("", e)
+        false
+      }
+      case e: ExitShellCommandException => {
         println(ShellColors.red(e.getMessage))
         _logger.debug("", e)
         false

--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/cmdline/RichCommandLine.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/cmdline/RichCommandLine.scala
@@ -21,7 +21,7 @@ package com.sumologic.shellbase.cmdline
 import java.io.File
 import java.lang.Boolean
 
-import com.sumologic.shellbase.{ShellPrompter, ValidationFailure, ValidationSuccess}
+import com.sumologic.shellbase.{ExitShellCommandException, ShellPrompter, ValidationFailure, ValidationSuccess}
 import org.apache.commons.cli.{CommandLine, GnuParser, HelpFormatter, Options, ParseException}
 
 /**
@@ -38,16 +38,16 @@ object RichCommandLine {
 }
 
 class RichScalaOption[T](optn: Option[T]) {
-  private[cmdline] def exit(exitCode: Int): Unit = System.exit(exitCode)
 
-  def getOrExitWithMessage(message: String, exitCode: Int = 1): T = {
+  private[cmdline] def exit(message: String): Unit = throw new ExitShellCommandException(message)
+
+  def getOrExitWithMessage(message: String): T = {
     optn match {
-      case Some(value) => value
-      case None => {
-        println(message)
-        exit(exitCode)
+      case Some(value) =>
+        value
+      case None =>
+        exit(message)
         null.asInstanceOf[T]
-      }
     }
   }
 }

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/cmdline/RichScalaOptionTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/cmdline/RichScalaOptionTest.scala
@@ -18,30 +18,21 @@
  */
 package com.sumologic.shellbase.cmdline
 
-import com.sumologic.shellbase.CommonWordSpec
+import com.sumologic.shellbase.{CommonWordSpec, ExitShellCommandException}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class RichScalaOptionTest extends CommonWordSpec {
   "RichScalaOption" should {
-    "get the value, or exit with specified code" in {
-      class VerySpecificException extends Exception
-      val code = 1234
+    "get the value when defined" in {
+      new RichScalaOption(Some("hi")).
+        getOrExitWithMessage("test message") should be("hi")
+    }
 
-      def fakeExit(c: Int): Unit = {
-        c should be(code)
-        throw new VerySpecificException
-      }
-
-      new RichScalaOption(Some("hi")) {
-        override def exit(exitCode: Int) = fakeExit(exitCode)
-      }.getOrExitWithMessage("test message", code) should be("hi")
-
-      intercept[VerySpecificException] {
-        new RichScalaOption[String](None) {
-          override def exit(exitCode: Int) = fakeExit(exitCode)
-        }.getOrExitWithMessage("test message", code)
+    "throw a ExitShellCommandException when the value isn't defined" in {
+      intercept[ExitShellCommandException] {
+        new RichScalaOption[String](None).getOrExitWithMessage("test message")
       }
     }
   }


### PR DESCRIPTION
When used within the context of `shellbase`, exiting the shell is almost never the desirable behavior of `getOrExitWithMessage`. This diff changes the behavior so that it fails the shell command and drops back to the prompt. 