### PR TITLE
Upgrade to JLine 2.14.6

### DIFF
--- a/shellbase-core/pom.xml
+++ b/shellbase-core/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
-      <version>2.12</version>
+      <version>2.14.6</version>
     </dependency>
 
     <dependency>

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBaseTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBaseTest.scala
@@ -199,14 +199,15 @@ class ShellBaseTest extends CommonWordSpec {
       val shell = new AutoCompleteTestShell
       shell.initializeCommands()
       val completer = shell.rootSet.argCompleter
-      val candidates = new util.LinkedList[CharSequence]()
-      val startPos = completer.complete(input, cursor, candidates)
+      val candidatesPlaceholder = new util.LinkedList[CharSequence]()
+      val startPos = completer.complete(input, cursor, candidatesPlaceholder)
+      val candidates = candidatesPlaceholder.asScala
 
       // adapted/copied logic from CandidateListCompletionHandler for full completion
-      if (candidates.size == 1 && cursor == input.length && !candidates.asScala.head.toString.endsWith(" ")) {
-        startPos -> List(candidates.asScala.head.toString + " ")
+      if (candidatesPlaceholder.size == 1 && cursor == input.length && !candidates.head.toString.endsWith(" ")) {
+        startPos -> List(candidates.head.toString + " ")
       } else {
-        startPos -> candidates.asScala.map(_.toString).toList
+        startPos -> candidates.map(_.toString).toList
       }
     }
 

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBaseTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBaseTest.scala
@@ -236,33 +236,33 @@ class ShellBaseTest extends CommonWordSpec {
       complete("ba", 2) should equal(0 -> List("ban", "bananas"))
       complete("ban", 2) should equal(0 -> List("ban", "bananas"))
       complete("ban", 3) should equal(0 -> List("ban", "bananas"))
-      complete("ban yellow b", 12) should equal(11 -> List("ban", "banners", "boxes "))
+      complete("ban yellow b", 12) should equal(11 -> List("ban", "banners", "boxes"))
     }
 
     "append a space when the choice is unambiguous" in {
-      complete("ban yell", 8) should equal(4 -> List("yellow "))
-      complete("ban yellow", 10) should equal(4 -> List("yellow "))
-      complete("pom", 3) should equal(0 -> List("pom "))
-      complete("persimmons", 3) should equal(0 -> List("persimmons "))
+      complete("ban yell", 8) should equal(4 -> List("yellow"))
+      complete("ban yellow", 10) should equal(4 -> List("yellow"))
+      complete("pom", 3) should equal(0 -> List("pom"))
+      complete("persimmons", 3) should equal(0 -> List("persimmons"))
     }
 
     "suggest candidate next tokens after the current one" in {
-      complete("ban ", 4) should equal(4 -> List("?", "help", "yellow "))
-      complete("ban yellow ", 11) should equal(11 -> List("?", "help", "ban", "banners", "boxes "))
+      complete("ban ", 4) should equal(4 -> List("?", "help", "yellow"))
+      complete("ban yellow ", 11) should equal(11 -> List("?", "help", "ban", "banners", "boxes"))
     }
 
     "complete properly when there are more characters after the one being completed" in {
-      complete("ban yell boxes", 8) should equal(4 -> List("yellow "))
-      complete("ban yellow b -skip none --permanent", 12) should equal(11 -> List("ban", "banners", "boxes "))
+      complete("ban yell boxes", 8) should equal(4 -> List("yellow"))
+      complete("ban yellow b -skip none --permanent", 12) should equal(11 -> List("ban", "banners", "boxes"))
       complete("ban yellow bags", 13)._2 should be('empty)
     }
 
     "account for extra whitespaces" in {
       complete("   app", 6) should equal(3 -> List("app", "apples"))
-      complete("   bananas", 10) should equal(3 -> List("bananas "))
-      complete("   bananas ", 11) should equal(11 -> List("?", "help", "yellow "))
-      complete("   bananas  ", 12) should equal(12 -> List("?", "help", "yellow "))
-      complete("   ban    yellow  banners", 25) should equal(18 -> List("banners "))
+      complete("   bananas", 10) should equal(3 -> List("bananas"))
+      complete("   bananas ", 11) should equal(11 -> List("?", "help", "yellow"))
+      complete("   bananas  ", 12) should equal(12 -> List("?", "help", "yellow"))
+      complete("   ban    yellow  banners", 25) should equal(18 -> List("banners"))
     }
   }
 


### PR DESCRIPTION
Upgrade to JLine 2.14.6 which is:
- the latest in the `2.x.x` line
- the same version as Scala REPL: https://github.com/scala/scala/blob/65102f7c6632aafb09c4620fc721a33fee206e86/versions.properties#L11

I am not expert in this library. They seem to have fixed some bug with autocompletion regarding adding trailing space in case of unambiguous match. In result, the behavior has slightly changed:
- the trailing space is added only if there's a single match (makes sense)
- the trailing space is added only if the cursor was at the end of the buffer even in case of unambiguous match (a matter of taste).

Copied this filling logic to `ShellBaseTest` and adapted the UT cases to match the new behavior.
