### PR TITLE
Ctrl-C with no command running clears the input buffer

### DIFF
--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellBase.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellBase.scala
@@ -150,7 +150,8 @@ abstract class ShellBase(val name: String) {
     }
   })
 
-  private val interruptKeyMonitor = new InterruptKeyMonitor()
+  // VisibleForTesting
+  private[shellbase] val interruptKeyMonitor = new InterruptKeyMonitor()
   interruptKeyMonitor.init()
 
   private val reader = new ConsoleReader()
@@ -267,7 +268,8 @@ abstract class ShellBase(val name: String) {
     println("Exiting...")
   }
 
-  private def runKillableCommand(line: String): Boolean = {
+  // VisibleForTesting
+  private[shellbase] def runKillableCommand(line: String): Boolean = {
     val commandRunner = new KillableSingleThread(runCommand(line))
 
     // Wait a bit for completion, so quick commands don't need to go through the keyMonitor.

--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellBase.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellBase.scala
@@ -26,7 +26,7 @@ import com.sumologic.shellbase.commands._
 import com.sumologic.shellbase.interrupts.{InterruptKeyMonitor, KillableSingleThread}
 import com.sumologic.shellbase.notifications._
 import com.sumologic.shellbase.timeutil.TimeFormats
-import jline.console.ConsoleReader
+import jline.console.{ConsoleReader, UserInterruptException}
 import jline.console.history.FileHistory
 import org.apache.commons.cli.{CommandLine, GnuParser, HelpFormatter, Options, ParseException, Option => CLIOption}
 import org.slf4j.LoggerFactory
@@ -155,7 +155,7 @@ abstract class ShellBase(val name: String) {
 
   private val reader = new ConsoleReader()
   reader.setHistory(history)
-  reader.setHandleUserInterrupt(false)
+  reader.setHandleUserInterrupt(true)
 
   def main(args: Array[String]) = {
     Thread.currentThread.setName("Shell main")
@@ -249,7 +249,11 @@ abstract class ShellBase(val name: String) {
 
     var keepRunning = true
     while (keepRunning) {
-      val line = reader.readLine(prompt)
+      val line = try {
+        reader.readLine(prompt)
+      } catch {
+        case _: UserInterruptException => "" // do nothing, that's fine
+      }
 
       // Line is null on CTRL-D...
       if (line == null) {

--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/interrupts/InterruptKeyMonitor.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/interrupts/InterruptKeyMonitor.scala
@@ -61,13 +61,15 @@ object InterruptKeyMonitor {
     def now = System.currentTimeMillis()
 
     override def handle(sig: Signal) {
-      if (now - lastInterrupt < 1000) {
-        println("Killing the shell...")
-        System.exit(1)
-      } else {
-        println("\nPress Ctrl-C again to exit.")
-        lastInterrupt = now
-        callbackOpt.foreach(_.apply())
+      if (callbackOpt.isDefined) {
+        if (now - lastInterrupt < 1000) {
+          println("Killing the shell...")
+          System.exit(1)
+        } else {
+          println("\nPress Ctrl-C again to exit.")
+          lastInterrupt = now
+          callbackOpt.foreach(_.apply())
+        }
       }
     }
   }

--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/interrupts/InterruptKeyMonitor.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/interrupts/InterruptKeyMonitor.scala
@@ -41,11 +41,16 @@ class InterruptKeyMonitor {
   def stopMonitoring(): Unit = {
     interruptKeyHandler.clearCallbacks()
   }
+
+  def isMonitoring: Boolean = {
+    interruptKeyHandler.hasACallback()
+  }
 }
 
 object InterruptKeyMonitor {
 
   class InterruptKeyHandler extends SignalHandler {
+
     type CallbackFn = () => Unit
     private var callbackOpt: Option[CallbackFn] = None
     private var lastInterrupt = 0L
@@ -57,6 +62,8 @@ object InterruptKeyMonitor {
     def clearCallbacks(): Unit = {
       callbackOpt = None
     }
+
+    def hasACallback(): Boolean = callbackOpt.isDefined
 
     def now = System.currentTimeMillis()
 

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBaseTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBaseTest.scala
@@ -19,16 +19,19 @@
 package com.sumologic.shellbase
 
 import java.util
+import java.util.concurrent.Semaphore
 
 import com.sumologic.shellbase.notifications.{InMemoryShellNotificationManager, ShellNotification, ShellNotificationManager}
 import org.apache.commons.cli.CommandLine
 import org.junit.runner.RunWith
+import org.scalatest.concurrent.Eventually
 import org.scalatest.junit.JUnitRunner
+import sun.misc.Signal
 
 import scala.collection.JavaConverters._
 
 @RunWith(classOf[JUnitRunner])
-class ShellBaseTest extends CommonWordSpec {
+class ShellBaseTest extends CommonWordSpec with Eventually {
 
   "ShellBase.main" should {
     "call init method and bubble exceptions" in {
@@ -192,6 +195,30 @@ class ShellBaseTest extends CommonWordSpec {
     }
   }
 
+  "ShellBase thread-handling" should {
+    "interrupt a long running command when Ctrl-C is pressed" in {
+      // given
+      val cmd = new LongRunningCommand("sleepysleep", durationInMillis = 100000L)
+      val sut = setUpShellBase(List(cmd))
+      val sutThread = new Thread {
+          override def run(): Unit = {
+            sut.runKillableCommand("sleepysleep")
+          }
+      }
+      sutThread.start()
+
+      // when
+      cmd.started.acquire()
+      Thread.sleep(500L) // that's longer than the 200ms initial quick-command period defined in runKillableCommand()
+      Signal.raise(new Signal("INT"))
+
+      // test
+      eventually { sutThread.isAlive should be (false) }
+      sut.interruptKeyMonitor.isMonitoring should be (false)
+      cmd.completedSuccessfully should be (false)
+    }
+  }
+
   "ShellBase auto-completion" should {
 
     def complete(input: String, cursor: Int): (Int, List[String]) = {
@@ -316,5 +343,20 @@ class DummyFailingCommand(name: String, aliases: List[String] = List()) extends 
   override def execute(cmdLine: CommandLine) = {
     super.execute(cmdLine)
     false
+  }
+}
+
+class LongRunningCommand(name: String, durationInMillis: Long, aliases: List[String] = List())
+  extends ShellCommand(name, "dummy", aliases) {
+
+  var completedSuccessfully = false
+  val started = new Semaphore(1)
+  started.acquire()
+
+  def execute(cmdLine: CommandLine) = {
+    started.release()
+    Thread.sleep(durationInMillis)
+    completedSuccessfully = true
+    true
   }
 }


### PR DESCRIPTION
Changing the Ctrl-C behavior:
- [CHANGE] when no command is running (user hasn't hit `<return>` yet) -> now it just clears the buffer
- [NO CHANGE] when a command is running ->
-- with the first hit the command is interrupted
-- if hit twice quickly, the whole shell is terminated

Why the change:
- this is how standard shells (readline-based, e.g. Bash) behave
