### PR TITLE
Prevent ThreadDeath stacktrace from being printed.

### DIFF
--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellBase.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellBase.scala
@@ -278,6 +278,7 @@ abstract class ShellBase(val name: String) {
           println(s"Caught interrupt.")
           println(s"Killing command with 1s grace period: `$line`...")
           commandRunner.kill(Duration(1, TimeUnit.SECONDS))
+          println("Killed.")
         }
       })
 

--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/interrupts/KillableSingleThread.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/interrupts/KillableSingleThread.scala
@@ -40,6 +40,7 @@ class KillableSingleThread[T](fn: => T) {
 
   private def interrupt(): Unit = {
     thread.interrupt()
+    resultPromise.tryFailure(new InterruptedException)
   }
 
   private def stop(): Unit = {


### PR DESCRIPTION
*WIP*.
Doesn't work as intended yet.