### PR TITLE
Fixing newlines in help.

### DIFF
--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommandSet.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommandSet.scala
@@ -166,13 +166,13 @@ class ShellCommandSet(name: String, helpText: String, aliases: List[String] = Li
         findCommand(command) match {
           case Some(shellCommandSet: ShellCommandSet) => shellCommandSet.printHelp(rest, showAllCommands)
           case Some(shellCommand) if rest.nonEmpty =>
-            println("Command '%s' doesn't have subcommands", command)
+            println(s"Command '$command' doesn't have subcommands")
             false
           case Some(shellCommand) =>
             shellCommand.help
             true
           case None =>
-            println("Command '%s' unknown.", command)
+            println(s"Command '$command' unknown.")
             false
         }
     }

--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommandSet.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellCommandSet.scala
@@ -166,13 +166,13 @@ class ShellCommandSet(name: String, helpText: String, aliases: List[String] = Li
         findCommand(command) match {
           case Some(shellCommandSet: ShellCommandSet) => shellCommandSet.printHelp(rest, showAllCommands)
           case Some(shellCommand) if rest.nonEmpty =>
-            printf("Command '%s' doesn't have subcommands", command)
+            println("Command '%s' doesn't have subcommands", command)
             false
           case Some(shellCommand) =>
             shellCommand.help
             true
           case None =>
-            printf("Command '%s' unknown.", command)
+            println("Command '%s' unknown.", command)
             false
         }
     }


### PR DESCRIPTION
Without it the indentation is wrong when using the `help` command, e.g.
```
[myshell] $ help ? help
Command '?' doesn't have subcommands[myshell] $ 
```

I haven't tested the change to be honest.