### PR TITLE
Start creating 2.0.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@
   <properties>
     <scala.version.major>2.11</scala.version.major>
     <scala.version>${scala.version.major}.12</scala.version>
-    <akka.version>2.3.11</akka.version>
   </properties>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
     <scala.version.major>2.11</scala.version.major>
-    <scala.version>${scala.version.major}.8</scala.version>
+    <scala.version>${scala.version.major}.12</scala.version>
     <akka.version>2.3.11</akka.version>
   </properties>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
+      <version>2.28.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.sumologic.shellbase</groupId>
   <artifactId>all</artifactId>
   <name>all</name>
-  <version>1.5.2-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,20 @@
       <version>3.0.8</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.9.5</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+      <version>4.12</version>
+    </dependency>
   </dependencies>
   <build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
           <!-- Enable that when we will migrate to new Scala major version (e.g. 2.11) -->
           <checkMultipleScalaVersions>false</checkMultipleScalaVersions>
           <args>
-            <arg>-target:jvm-1.6</arg>
+            <arg>-target:jvm-1.8</arg>
             <arg>-dependencyfile</arg>
             <arg>${project.build.directory}/.scala_dependencies</arg>
             <arg>-deprecation</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.version.major}</artifactId>
-      <version>2.2.6</version>
+      <version>3.0.8</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.version.major}</artifactId>
       <version>2.2.6</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.1.6</version>
+        <version>3.4.6</version>
         <executions>
           <execution>
             <id>test-compile</id>
@@ -90,7 +90,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -104,7 +104,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.7</version>
+        <version>2.22.2</version>
         <configuration>
           <skipTests>true</skipTests>
         </configuration>
@@ -113,7 +113,7 @@
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
-        <version>1.0</version>
+        <version>2.0.0</version>
         <configuration>
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
           <junitxml>.</junitxml>
@@ -131,7 +131,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.5.201505241946</version>
+        <version>0.8.4</version>
         <executions>
           <execution>
             <goals>
@@ -187,7 +187,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
+        <version>1.6</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -201,7 +201,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.5.1</version>
+        <version>1.6.8</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>sonatype-nexus-staging</serverId>

--- a/shellbase-core/pom.xml
+++ b/shellbase-core/pom.xml
@@ -67,13 +67,6 @@
 
     <!-- Test Dependencies. -->
     <dependency>
-      <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_${scala.version.major}</artifactId>
-      <scope>test</scope>
-      <version>2.1.7</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.9.5</version>

--- a/shellbase-core/pom.xml
+++ b/shellbase-core/pom.xml
@@ -3,12 +3,12 @@
   <artifactId>shellbase-core</artifactId>
   <name>shellbase-core</name>
   <packaging>jar</packaging>
-  <version>1.5.2-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
 
   <parent>
     <artifactId>all</artifactId>
     <groupId>com.sumologic.shellbase</groupId>
-    <version>1.5.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/shellbase-core/pom.xml
+++ b/shellbase-core/pom.xml
@@ -64,21 +64,6 @@
       <artifactId>scala-library</artifactId>
       <version>${scala.version}</version>
     </dependency>
-
-    <!-- Test Dependencies. -->
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-      <version>4.12</version>
-    </dependency>
   </dependencies>
 
 </project>

--- a/shellbase-core/pom.xml
+++ b/shellbase-core/pom.xml
@@ -26,25 +26,25 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.9.3</version>
+      <version>2.10.2</version>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.21</version>
+      <version>1.7.26</version>
     </dependency>
 
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.2</version>
+      <version>1.4</version>
     </dependency>
 
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.6</version>
     </dependency>
 
     <dependency>

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ScriptRendererSpec.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ScriptRendererSpec.scala
@@ -21,7 +21,7 @@ package com.sumologic.shellbase
 import java.io.File
 
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ScriptRendererSpec extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBannerTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBannerTest.scala
@@ -19,7 +19,7 @@
 package com.sumologic.shellbase
 
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ShellBannerTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBaseTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBaseTest.scala
@@ -22,11 +22,10 @@ import java.util
 import java.util.concurrent.Semaphore
 
 import com.sumologic.shellbase.notifications.{InMemoryShellNotificationManager, ShellNotification, ShellNotificationManager}
-import jline.console.completer.CandidateListCompletionHandler
 import org.apache.commons.cli.CommandLine
 import org.junit.runner.RunWith
 import org.scalatest.concurrent.Eventually
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import sun.misc.Signal
 import org.mockito.Mockito._
 

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellColorsTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellColorsTest.scala
@@ -19,7 +19,7 @@
 package com.sumologic.shellbase
 
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ShellColorsTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellCommandAliasTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellCommandAliasTest.scala
@@ -19,11 +19,11 @@
 package com.sumologic.shellbase
 
 import com.sumologic.shellbase.cmdline.RichCommandLine._
-import com.sumologic.shellbase.cmdline.{CommandLineOption, RichCommandLine}
+import com.sumologic.shellbase.cmdline.CommandLineOption
 import org.apache.commons.cli.{CommandLine, Options}
 import org.junit.runner.RunWith
 import org.mockito.Mockito._
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ShellCommandAliasTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellCommandSetTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellCommandSetTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase
 
 import org.apache.commons.cli.CommandLine
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ShellCommandSetTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellFormattingTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellFormattingTest.scala
@@ -19,7 +19,7 @@
 package com.sumologic.shellbase
 
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ShellFormattingTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellHighlightsTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellHighlightsTest.scala
@@ -19,7 +19,7 @@
 package com.sumologic.shellbase
 
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ShellHighlightsTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellPromptValidatorsTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellPromptValidatorsTest.scala
@@ -23,7 +23,7 @@ import java.nio.file.Files
 
 import com.sumologic.shellbase.ShellPromptValidators._
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ShellPromptValidatorsTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellPrompterTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellPrompterTest.scala
@@ -24,7 +24,7 @@ import java.util.Date
 
 import jline.console.ConsoleReader
 import org.junit.runner.RunWith
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers.{eq => matcheq, _}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.junit.JUnitRunner
@@ -291,6 +291,7 @@ class ShellPrompterTest extends CommonWordSpec with BeforeAndAfterEach with Mock
 
   private def answerQuestionWith(str1: String, str: String*): Unit = {
     when(mockReader.readLine(anyString, anyChar)).thenReturn(str1, str: _*)
+    when(mockReader.readLine(anyString, matcheq(null))).thenReturn(str1, str: _*)
   }
 
   private def feedCharacters(string: String): Unit = {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellPrompterTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellPrompterTest.scala
@@ -27,8 +27,8 @@ import org.junit.runner.RunWith
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.junit.JUnitRunner
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.collection.mutable
 

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellStringSupportTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellStringSupportTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase
 
 import com.sumologic.shellbase.ShellStringSupport._
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ShellStringSupportTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/cmdline/ArgumentTrackingOptionsTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/cmdline/ArgumentTrackingOptionsTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase.cmdline
 
 import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ArgumentTrackingOptionsTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/cmdline/CommandLineValidatorsTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/cmdline/CommandLineValidatorsTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase.cmdline
 
 import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class CommandLineValidatorsTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/cmdline/RichCommandLineTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/cmdline/RichCommandLineTest.scala
@@ -22,7 +22,7 @@ import com.sumologic.shellbase.CommonWordSpec
 import com.sumologic.shellbase.cmdline.RichCommandLine._
 import org.apache.commons.cli.Options
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class RichCommandLineTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/cmdline/RichScalaOptionTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/cmdline/RichScalaOptionTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase.cmdline
 
 import com.sumologic.shellbase.{CommonWordSpec, ExitShellCommandException}
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class RichScalaOptionTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/ClearCommandTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/ClearCommandTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase.commands
 
 import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ClearCommandTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/EchoCommandTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/EchoCommandTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase.commands
 
 import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class EchoCommandTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/ExitCommandTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/ExitCommandTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase.commands
 
 import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ExitCommandTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/RunScriptCommandTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/RunScriptCommandTest.scala
@@ -22,7 +22,7 @@ import java.io.File
 
 import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class RunScriptCommandTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/SleepCommandTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/SleepCommandTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase.commands
 
 import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class SleepCommandTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/TeeCommandTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/TeeCommandTest.scala
@@ -23,7 +23,7 @@ import java.nio.file.{Files, Path}
 
 import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 import scala.collection.JavaConverters._
 import scala.util.Random

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/TimeCommandTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/commands/TimeCommandTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase.commands
 
 import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class TimeCommandTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/interrupts/KillableSingleThreadTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/interrupts/KillableSingleThreadTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase.interrupts
 
 import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/notifications/InMemoryShellNotificationManagerTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/notifications/InMemoryShellNotificationManagerTest.scala
@@ -22,8 +22,8 @@ import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.junit.JUnitRunner
+import org.scalatestplus.mockito.MockitoSugar
 
 @RunWith(classOf[JUnitRunner])
 class InMemoryShellNotificationManagerTest extends CommonWordSpec with BeforeAndAfterEach with MockitoSugar {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/notifications/NotificationCommandSetTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/notifications/NotificationCommandSetTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase.notifications
 
 import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class NotificationCommandSetTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/table/ASCIITableTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/table/ASCIITableTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase.table
 
 import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 
 @RunWith(classOf[JUnitRunner])

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/table/HTMLTableTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/table/HTMLTableTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase.table
 
 import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class HTMLTableTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/timeutil/TimeFormatsTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/timeutil/TimeFormatsTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase.timeutil
 
 import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class TimeFormatsTest extends CommonWordSpec {

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/timeutil/TimedBlockTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/timeutil/TimedBlockTest.scala
@@ -20,7 +20,7 @@ package com.sumologic.shellbase.timeutil
 
 import com.sumologic.shellbase.CommonWordSpec
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class TimedBlockTest extends CommonWordSpec {

--- a/shellbase-example/pom.xml
+++ b/shellbase-example/pom.xml
@@ -3,12 +3,12 @@
   <artifactId>shellbase-example</artifactId>
   <name>shellbase-example</name>
   <packaging>jar</packaging>
-  <version>1.5.2-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
 
   <parent>
     <artifactId>all</artifactId>
     <groupId>com.sumologic.shellbase</groupId>
-    <version>1.5.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.sumologic.shellbase</groupId>
       <artifactId>shellbase-core</artifactId>
-      <version>1.5.2-SNAPSHOT</version>
+      <version>2.0.0-SNAPSHOT</version>
     </dependency>
 
   </dependencies>

--- a/shellbase-slack/pom.xml
+++ b/shellbase-slack/pom.xml
@@ -31,7 +31,7 @@
 
     <dependency>
       <groupId>com.flyberrycapital</groupId>
-      <artifactId>scala-slack_2.11</artifactId>
+      <artifactId>scala-slack_${scala.version.major}</artifactId>
       <version>0.2.0</version>
     </dependency>
 

--- a/shellbase-slack/pom.xml
+++ b/shellbase-slack/pom.xml
@@ -37,13 +37,6 @@
 
     <!-- Test Dependencies. -->
     <dependency>
-      <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_${scala.version.major}</artifactId>
-      <scope>test</scope>
-      <version>2.1.7</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.9.5</version>

--- a/shellbase-slack/pom.xml
+++ b/shellbase-slack/pom.xml
@@ -35,21 +35,6 @@
       <version>0.3.1</version>
     </dependency>
 
-    <!-- Test Dependencies. -->
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-      <version>4.12</version>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/shellbase-slack/pom.xml
+++ b/shellbase-slack/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>com.flyberrycapital</groupId>
       <artifactId>scala-slack_${scala.version.major}</artifactId>
-      <version>0.2.0</version>
+      <version>0.3.1</version>
     </dependency>
 
     <!-- Test Dependencies. -->

--- a/shellbase-slack/pom.xml
+++ b/shellbase-slack/pom.xml
@@ -3,12 +3,12 @@
   <artifactId>shellbase-slack</artifactId>
   <name>shellbase-slack</name>
   <packaging>jar</packaging>
-  <version>1.5.2-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
 
   <parent>
     <artifactId>all</artifactId>
     <groupId>com.sumologic.shellbase</groupId>
-    <version>1.5.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.sumologic.shellbase</groupId>
       <artifactId>shellbase-core</artifactId>
-      <version>1.5.2-SNAPSHOT</version>
+      <version>2.0.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostCommandToSlackTest.scala
+++ b/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostCommandToSlackTest.scala
@@ -24,7 +24,7 @@ import com.sumologic.shellbase.ShellCommand
 import org.apache.commons.cli.CommandLine
 import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.mockito.Mockito._
 import org.mockito.Matchers.{eq => matcher_eq, _}
 import org.scalatest.mock.MockitoSugar

--- a/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostCommandToSlackTest.scala
+++ b/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostCommandToSlackTest.scala
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.junit.JUnitRunner
 import org.mockito.Mockito._
-import org.mockito.Matchers.{eq => matcher_eq, _}
+import org.mockito.ArgumentMatchers.{eq => matcher_eq, _}
 import org.scalatest.mock.MockitoSugar
 
 @RunWith(classOf[JUnitRunner])

--- a/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostCommandWithSlackThreadTest.scala
+++ b/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostCommandWithSlackThreadTest.scala
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith
 import org.mockito.Matchers.{any, anyObject, anyString}
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Matchers.{eq => matcher_eq, _}
 

--- a/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostCommandWithSlackThreadTest.scala
+++ b/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostCommandWithSlackThreadTest.scala
@@ -24,12 +24,12 @@ import com.flyberrycapital.slack.Responses.PostMessageResponse
 import com.flyberrycapital.slack.SlackClient
 import org.apache.commons.cli.CommandLine
 import org.junit.runner.RunWith
-import org.mockito.Matchers.{any, anyObject, anyString}
+import org.mockito.ArgumentMatchers.{any, anyObject, anyString}
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.mock.MockitoSugar
-import org.mockito.Matchers.{eq => matcher_eq, _}
+import org.mockito.ArgumentMatchers.{eq => matcher_eq, _}
 
 @RunWith(classOf[JUnitRunner])
 class PostCommandWithSlackThreadTest extends CommonWordSpec with BeforeAndAfterEach with MockitoSugar {

--- a/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostToSlackHelperTest.scala
+++ b/shellbase-slack/src/test/scala/com/sumologic/shellbase/slack/PostToSlackHelperTest.scala
@@ -19,7 +19,7 @@
 package com.sumologic.shellbase.slack
 
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class PostToSlackHelperTest extends CommonWordSpec {


### PR DESCRIPTION
1. Upgrades as many things as possible (except jline - that's a bigger effort)
2. Drop support for Java 6/7
3. Some general cleaning
4. Changes versions to 2.0.0-SNAPSHOT

Future changes:
1. Switch to Gradle, which allows cross-compiling on 2.11 and 2.12
2. Switch artifact names to end in `_${scala.version.major}` which is the industry standard