### PR TITLE
Help Travis to build correctly by forcing it to use correct jdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - openjdk8
 install: mvn install -DskipTests=true -Dgpg.skip=true
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Travis was failing every recent build due to `MissingRequirementError`
```
[ERROR] error: scala.reflect.internal.MissingRequirementError: object java.lang.Object in compiler mirror not found.
[ERROR] 	at scala.reflect.internal.MissingRequirementError$.signal(MissingRequirementError.scala:17)
[ERROR] 	at scala.reflect.internal.MissingRequirementError$.notFound(MissingRequirementError.scala:18)
```
Failed builds were operating on `openjdk version "11.0.2" 2019-01-15` in comparison to the latest successful builds with `java version "1.8.0_151"`

This was fixed by setting correct jdk in `.travis.yml`

Tested by triggering custom `master` builds with changed configuration.