### PR TITLE
Releasing Shellbase 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [1.5.2] - 2019-11-19
+## [1.5.2] - 2019-11-20
 
 ### Added
 - Multiple Scala Version support: `2.11`, `2.12`

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ These are the components we provide:
     <dependency>
       <groupId>com.sumologic.shellbase</groupId>
       <artifactId>shellbase-core_2.11</artifactId>
-      <version>1.5.1</version>
+      <version>1.5.2</version>
     </dependency>
 
     <dependency>
       <groupId>com.sumologic.shellbase</groupId>
       <artifactId>shellbase-slack_2.11</artifactId>
-      <version>1.5.1</version>
+      <version>1.5.2</version>
     </dependency>
 ```
 
@@ -80,9 +80,9 @@ outside this list)
         signing.gnupg.passphrase=${password_for_imported_sumoapi_key}
         ```
 2. Remove `-SNAPSHOT` suffix from `version` in `build.gradle`
-3. Make a release branch with Scala version and project version, ex. `shellbase-1.5.2`:
+3. Make a release branch with Scala version and project version, ex. `shellbase-1.5.3`:
     ```
-    export RELEASE_VERSION=shellbase-1.5.2
+    export RELEASE_VERSION=shellbase-1.5.3
     git checkout -b ${RELEASE_VERSION}
     git add build.gradle
     git commit -m "[release] ${RELEASE_VERSION}"
@@ -95,7 +95,7 @@ outside this list)
 5. Go to https://oss.sonatype.org/index.html#stagingRepositories, search for com.sumologic and release your repo. 
 NOTE: If you had to login, reload the URL. It doesn't take you to the right page post-login
 6. Update the `README.md` and `CHANGELOG.md` with the new version and set upcoming snapshot `version` 
-in `build.gradle`, ex. `1.5.3-SNAPSHOT` 
+in `build.gradle`, ex. `1.5.4-SNAPSHOT` 
 7. Commit the change and push as a PR:
     ```
     git add build.gradle README.md CHANGELOG.md

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ allprojects {
     group = "com.sumologic.shellbase"
     description = "Sumo Logic's Scala-based interactive shell framework"
 
-    version = '1.5.2-SNAPSHOT'
+    version = '1.5.2'
 
     sourceCompatibility = javaSourceVersion
     targetCompatibility = javaTargetVersion

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ allprojects {
     group = "com.sumologic.shellbase"
     description = "Sumo Logic's Scala-based interactive shell framework"
 
-    version = '1.5.2'
+    version = '1.5.3-SNAPSHOT'
 
     sourceCompatibility = javaSourceVersion
     targetCompatibility = javaTargetVersion


### PR DESCRIPTION
###### Description

Publicly releasing Shellbase 1.5.2 as:
`shellbase-core_2.11:1.5.2`
`shellbase-slack_2.11:1.5.2`
`shellbase-example_2.11:1.5.2`
`shellbase-core_2.12:1.5.2`
`shellbase-slack_2.12:1.5.2`
`shellbase-example_2.12:1.5.2`

###### Testing performed

- [x] Released to local maven and run tests on internal project using updated version (`gradlew build publishToMavenLocal`)