### PR TITLE
Adding nexus-required developers config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,13 @@ subprojects {
                             url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                         }
                     }
+                    developers {
+                        developer {
+                            id = 'goledzki'
+                            name = 'Greg Oledzki'
+                            organization = 'Sumo Logic'
+                        }
+                    }
                     scm {
                         connection = 'scm:git:git@github.com:SumoLogic/shellbase.git'
                         developerConnection = 'scm:git:git@github.com:SumoLogic/shellbase.git'


### PR DESCRIPTION
Developers information is required to successfully close the staging repository in Nexus