### PR TITLE
Don't exit if the exit code is 0

### DIFF
--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellBase.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellBase.scala
@@ -163,7 +163,11 @@ abstract class ShellBase(val name: String)
     Thread.currentThread.setName("Shell main")
     try {
       val result = actualMain(args)
-      exitShell(result)
+      if (result != 0) {
+        exitShell(result)
+      } else {
+        // let the program end naturally
+      }
     } finally {
       interruptKeyMonitor.shutdown()
     }

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBaseTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBaseTest.scala
@@ -47,9 +47,9 @@ class ShellBaseTest extends CommonWordSpec with Eventually {
       }
     }
 
-    "exit after executing all the command line arguments" in {
+    "should not exit after successfully executing all the command line arguments" in {
       // given
-      var exitCode: Int = -1
+      var exitCode: Int = -100
       class ShellOneCanExit extends ShellBase("test") {
         override def commands: Seq[ShellCommand] = Seq(new DummyCommand("callme"))
 
@@ -63,7 +63,7 @@ class ShellBaseTest extends CommonWordSpec with Eventually {
       sut.main(Seq("callme").toArray)
 
       // then
-      exitCode should be(0)
+      exitCode should be(-100)
     }
 
     "exit with non-zero exit code after executing a command line argument command fails" in {


### PR DESCRIPTION
Currently:
ShellBase exits with `System.exit(0)` if everything went well

That is incompatible with how Jenkins runs Maven jobs. As it discovers such exits (probably the call the `.main` manually) and mark the job as failed despite everything as fine, e.g.
```
03:23:40 ERROR: Maven JVM terminated unexpectedly with exit code 0
```

It's kind of lame, but instead of fixing Jenkins Maven plugin, let's have a workaround here.
