### PR TITLE
Revert "Don't exit if the exit code is 0"

### DIFF
--- a/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellBase.scala
+++ b/shellbase-core/src/main/scala/com/sumologic/shellbase/ShellBase.scala
@@ -163,11 +163,7 @@ abstract class ShellBase(val name: String)
     Thread.currentThread.setName("Shell main")
     try {
       val result = actualMain(args)
-      if (result != 0) {
-        exitShell(result)
-      } else {
-        // let the program end naturally
-      }
+      exitShell(result)
     } finally {
       interruptKeyMonitor.shutdown()
     }

--- a/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBaseTest.scala
+++ b/shellbase-core/src/test/scala/com/sumologic/shellbase/ShellBaseTest.scala
@@ -47,9 +47,9 @@ class ShellBaseTest extends CommonWordSpec with Eventually {
       }
     }
 
-    "should not exit after successfully executing all the command line arguments" in {
+    "exit after executing all the command line arguments" in {
       // given
-      var exitCode: Int = -100
+      var exitCode: Int = -1
       class ShellOneCanExit extends ShellBase("test") {
         override def commands: Seq[ShellCommand] = Seq(new DummyCommand("callme"))
 
@@ -63,7 +63,7 @@ class ShellBaseTest extends CommonWordSpec with Eventually {
       sut.main(Seq("callme").toArray)
 
       // then
-      exitCode should be(-100)
+      exitCode should be(0)
     }
 
     "exit with non-zero exit code after executing a command line argument command fails" in {


### PR DESCRIPTION
Reverts SumoLogic/shellbase#46.

It turned out to be wrong in non-trivial scenario of the shell starting an external process. With #46 the behavior was that the shell process hang.